### PR TITLE
fixed usage of Vector constructor in hmac-functions

### DIFF
--- a/src/SHA.jl
+++ b/src/SHA.jl
@@ -72,7 +72,7 @@ for (f, ctx) in [(:sha1, :SHA1_CTX),
         end
         function $g(key::Vector{UInt8}, io::IO, chunk_size=4*1024)
             ctx = HMAC_CTX($ctx(), key)
-            buff = Vector{UInt8}(chunk_size)
+            buff = Vector{UInt8}(undef, chunk_size)
             while !eof(io)
                 num_read = readbytes!(io, buff)
                 update!(ctx, buff, num_read)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -69,8 +69,10 @@ end
     # test hmac correctness using the examples from Wikipedia:
     # https://en.wikipedia.org/wiki/Hash-based_message_authentication_code#Examples
     for (key, msg, fun, hash) in hmac_data
-        digest = bytes2hex(fun(Vector{UInt8}(key), Vector{UInt8}(msg)))
-        @test digest == hash
+        digest1 = bytes2hex(fun(Vector{UInt8}(key), Vector{UInt8}(msg)))
+        digest2 = bytes2hex(fun(Vector{UInt8}(key), IOBuffer(msg)))
+        @test digest1 == hash
+        @test digest2 == hash
     end
 end
 


### PR DESCRIPTION
`hmac_sha512(::Vector{UInt8}, ::IOBuffer)` works now and test cases do exist.