### PR TITLE
Bring improvements from `Base` Julia out to `SHA.jl`

### DIFF
--- a/src/SHA.jl
+++ b/src/SHA.jl
@@ -1,4 +1,38 @@
+"""
+    SHA
+
+The SHA module provides hashing functionality for SHA1, SHA2 and SHA3 algorithms.
+
+They are implemented as both pure functions for hashing single pieces of data,
+or a stateful context which can be updated with the `update!` function and
+finalized with `digest!`.
+
+```julia-repl
+julia> sha1(b"some data")
+20-element Vector{UInt8}:
+ 0xba
+ 0xf3
+    ⋮
+ 0xe3
+ 0x56
+
+
+julia> ctx = SHA1_CTX()
+SHA1 hash state
+
+julia> update!(ctx, b"some data")
+0x0000000000000009
+
+julia> digest!(ctx)
+20-element Vector{UInt8}:
+ 0xba
+ 0xf3
+    ⋮
+ 0xe3
+ 0x56
+"""
 module SHA
+
 # Export convenience functions, context types, update!() and digest!() functions
 export sha1, SHA1_CTX, update!, digest!
 export sha224, sha256, sha384, sha512
@@ -42,9 +76,23 @@ for (f, ctx) in [(:sha1, :SHA1_CTX),
 
     @eval begin
         # Our basic function is to process arrays of bytes
-        function $f(data::AbstractBytes, ctx=$ctx())
+        """
+            $($f)(data)
+
+        Hash data using the $($f) algorithm and return the resulting digest.
+        See also [`$($ctx)`](@ref).
+        """
+        function $f(data::AbstractBytes)
+            ctx = $ctx()
             update!(ctx, data)
             return digest!(ctx)
+
+        """
+            $($g)(key, data)
+
+        Hash data using the $($f) algorithm using the passed key
+        See also [`HMAC_CTX`](@ref).
+        """
         end
         function $g(key::Vector{UInt8}, data::AbstractBytes)
             ctx = HMAC_CTX($ctx(), key)
@@ -58,11 +106,13 @@ for (f, ctx) in [(:sha1, :SHA1_CTX),
         $g(key::Vector{UInt8}, str::AbstractString) = $g(key, String(str))
         $g(key::Vector{UInt8}, str::String) = $g(key, codeunits(str))
 
-        # Convenience function for IO devices, allows for things like:
-        # open("test.txt") do f
-        #     sha256(f)
-        # done
-        function $f(io::IO, chunk_size=4*1024, ctx=$ctx())
+        """
+            $($f)(io::IO)
+
+        Hash data from io using $($f) algorithm from io.
+        """
+        function $f(io::IO, chunk_size=4*1024)
+            ctx = $ctx()
             buff = Vector{UInt8}(undef, chunk_size)
             while !eof(io)
                 num_read = readbytes!(io, buff)
@@ -72,7 +122,7 @@ for (f, ctx) in [(:sha1, :SHA1_CTX),
         end
         function $g(key::Vector{UInt8}, io::IO, chunk_size=4*1024)
             ctx = HMAC_CTX($ctx(), key)
-            buff = Vector{UInt8}(chunk_size)
+            buff = Vector{UInt8}(undef, chunk_size)
             while !eof(io)
                 num_read = readbytes!(io, buff)
                 update!(ctx, buff, num_read)

--- a/src/common.jl
+++ b/src/common.jl
@@ -2,6 +2,20 @@
 
 # update! takes in variable-length data, buffering it into blocklen()-sized pieces,
 # calling transform!() when necessary to update the internal hash state.
+"""
+    update!(context, data[, datalen])
+
+Update the SHA context with the bytes in data. See also [`digest!`](@ref) for
+finalizing the hash.
+
+# Examples
+```julia-repl
+julia> ctx = SHA1_CTX()
+SHA1 hash state
+
+julia> update!(ctx, b"data to to be hashed")
+```
+"""
 function update!(context::T, data::U, datalen=length(data)) where {T<:SHA_CTX, U<:AbstractBytes}
     # We need to do all our arithmetic in the proper bitwidth
     UIntXXX = typeof(context.bytecount)
@@ -64,6 +78,27 @@ end
 
 # Clear out any saved data in the buffer, append total bitlength, and return our precious hash!
 # Note: SHA3_CTX has a more specialised method
+"""
+    digest!(context)
+
+Finalize the SHA context and return the hash as array of bytes (Array{Uint8, 1}).
+
+# Examples
+```julia-repl
+julia> ctx = SHA1_CTX()
+SHA1 hash state
+
+julia> update!(ctx, b"data to to be hashed")
+
+julia> digest!(ctx)
+20-element Array{UInt8,1}:
+ 0x83
+ 0xe4
+ ⋮
+ 0x89
+ 0xf5
+```
+"""
 function digest!(context::T) where T<:SHA_CTX
     pad_remainder!(context)
     # Store the length of the input data (in bits) at the end of the padding

--- a/src/types.jl
+++ b/src/types.jl
@@ -39,6 +39,21 @@ mutable struct SHA2_512_CTX <: SHA2_CTX
     buffer::Array{UInt8,1}
 end
 
+function Base.getproperty(ctx::SHA2_CTX, fieldname::Symbol)
+    if fieldname === :state
+        return getfield(ctx, :state)::Union{Vector{UInt32},Vector{UInt64}}
+    elseif fieldname === :bytecount
+        return getfield(ctx, :bytecount)::Union{UInt64,UInt128}
+    elseif fieldname === :buffer
+        return getfield(ctx, :buffer)::Vector{UInt8}
+    elseif fieldname === :W
+        return getfield(ctx, :W)::Vector{UInt32}
+    else
+        error("SHA2_CTX has no field ", fieldname)
+    end
+end
+
+
 # Typealias common nicknames for SHA2 family of functions
 const SHA224_CTX = SHA2_224_CTX
 const SHA256_CTX = SHA2_256_CTX
@@ -70,6 +85,20 @@ mutable struct SHA3_512_CTX <: SHA3_CTX
     bytecount::UInt128
     buffer::Array{UInt8,1}
     bc::Array{UInt64,1}
+end
+
+function Base.getproperty(ctx::SHA3_CTX, fieldname::Symbol)
+    if fieldname === :state
+        return getfield(ctx, :state)::Vector{UInt64}
+    elseif fieldname === :bytecount
+        return getfield(ctx, :bytecount)::UInt128
+    elseif fieldname === :buffer
+        return getfield(ctx, :buffer)::Vector{UInt8}
+    elseif fieldname === :bc
+        return getfield(ctx, :bc)::Vector{UInt64}
+    else
+        error("type ", typeof(ctx), " has no field ", fieldname)
+    end
 end
 
 # Define constants via functions so as not to bloat context objects.  Yay dispatch!
@@ -110,14 +139,55 @@ blocklen(::Type{SHA3_512_CTX}) = UInt64(25*8 - 2*digestlen(SHA3_512_CTX))
 short_blocklen(::Type{T}) where {T<:SHA_CTX} = blocklen(T) - 2*sizeof(state_type(T))
 
 # Once the "blocklen" methods are defined, we can define our outer constructors for SHA types:
+
+"""
+    SHA2_224_CTX()
+
+Construct an empty SHA2_224 context.
+"""
 SHA2_224_CTX() = SHA2_224_CTX(copy(SHA2_224_initial_hash_value), 0, zeros(UInt8, blocklen(SHA2_224_CTX)))
+"""
+    SHA2_256_CTX()
+
+Construct an empty SHA2_256 context.
+"""
 SHA2_256_CTX() = SHA2_256_CTX(copy(SHA2_256_initial_hash_value), 0, zeros(UInt8, blocklen(SHA2_256_CTX)))
+"""
+    SHA2_384()
+
+Construct an empty SHA2_384 context.
+"""
 SHA2_384_CTX() = SHA2_384_CTX(copy(SHA2_384_initial_hash_value), 0, zeros(UInt8, blocklen(SHA2_384_CTX)))
+"""
+    SHA2_512_CTX()
+
+Construct an empty SHA2_512 context.
+"""
 SHA2_512_CTX() = SHA2_512_CTX(copy(SHA2_512_initial_hash_value), 0, zeros(UInt8, blocklen(SHA2_512_CTX)))
 
+"""
+    SHA3_224_CTX()
+
+Construct an empty SHA3_224 context.
+"""
 SHA3_224_CTX() = SHA3_224_CTX(zeros(UInt64, 25), 0, zeros(UInt8, blocklen(SHA3_224_CTX)), Vector{UInt64}(undef, 5))
+"""
+    SHA3_256_CTX()
+
+Construct an empty SHA3_256 context.
+"""
 SHA3_256_CTX() = SHA3_256_CTX(zeros(UInt64, 25), 0, zeros(UInt8, blocklen(SHA3_256_CTX)), Vector{UInt64}(undef, 5))
+"""
+    SHA3_384_CTX()
+
+Construct an empty SHA3_384 context.
+"""
 SHA3_384_CTX() = SHA3_384_CTX(zeros(UInt64, 25), 0, zeros(UInt8, blocklen(SHA3_384_CTX)), Vector{UInt64}(undef, 5))
+"""
+    SHA3_512_CTX()
+
+Construct an empty SHA3_512 context.
+"""
 SHA3_512_CTX() = SHA3_512_CTX(zeros(UInt64, 25), 0, zeros(UInt8, blocklen(SHA3_512_CTX)), Vector{UInt64}(undef, 5))
 
 # Nickname'd outer constructor methods for SHA2
@@ -127,6 +197,11 @@ const SHA384_CTX = SHA2_384_CTX
 const SHA512_CTX = SHA2_512_CTX
 
 # SHA1 is special; he needs extra workspace
+"""
+    SHA1_CTX()
+
+Construct an empty SHA1 context.
+"""
 SHA1_CTX() = SHA1_CTX(copy(SHA1_initial_hash_value), 0, zeros(UInt8, blocklen(SHA1_CTX)), Vector{UInt32}(undef, 80))
 
 
@@ -138,15 +213,15 @@ copy(ctx::T) where {T<:SHA3_CTX} = T(copy(ctx.state), ctx.bytecount, copy(ctx.bu
 
 # Make printing these types a little friendlier
 import Base.show
-show(io::IO, ::SHA1_CTX) = write(io, "SHA1 hash state")
-show(io::IO, ::SHA2_224_CTX) = write(io, "SHA2 224-bit hash state")
-show(io::IO, ::SHA2_256_CTX) = write(io, "SHA2 256-bit hash state")
-show(io::IO, ::SHA2_384_CTX) = write(io, "SHA2 384-bit hash state")
-show(io::IO, ::SHA2_512_CTX) = write(io, "SHA2 512-bit hash state")
-show(io::IO, ::SHA3_224_CTX) = write(io, "SHA3 224-bit hash state")
-show(io::IO, ::SHA3_256_CTX) = write(io, "SHA3 256-bit hash state")
-show(io::IO, ::SHA3_384_CTX) = write(io, "SHA3 384-bit hash state")
-show(io::IO, ::SHA3_512_CTX) = write(io, "SHA3 512-bit hash state")
+show(io::IO, ::SHA1_CTX) = print(io, "SHA1 hash state")
+show(io::IO, ::SHA2_224_CTX) = print(io, "SHA2 224-bit hash state")
+show(io::IO, ::SHA2_256_CTX) = print(io, "SHA2 256-bit hash state")
+show(io::IO, ::SHA2_384_CTX) = print(io, "SHA2 384-bit hash state")
+show(io::IO, ::SHA2_512_CTX) = print(io, "SHA2 512-bit hash state")
+show(io::IO, ::SHA3_224_CTX) = print(io, "SHA3 224-bit hash state")
+show(io::IO, ::SHA3_256_CTX) = print(io, "SHA3 256-bit hash state")
+show(io::IO, ::SHA3_384_CTX) = print(io, "SHA3 384-bit hash state")
+show(io::IO, ::SHA3_512_CTX) = print(io, "SHA3 512-bit hash state")
 
 
 # use our types to define a method to get a pointer to the state buffer

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -71,6 +71,8 @@ end
     for (key, msg, fun, hash) in hmac_data
         digest = bytes2hex(fun(Vector{UInt8}(key), Vector{UInt8}(msg)))
         @test digest == hash
+        digest = bytes2hex(fun(Vector{UInt8}(key), IOBuffer(msg)))
+        @test digest == hash
     end
 end
 


### PR DESCRIPTION
Some development had occured on the copy of SHA that was vendored into
Base Julia.  This merges the changes (mostly documentation) into this
external package, in preparation of moving SHA over to be an "external
stdlib".
