### PR TITLE
Add NIST test set

### DIFF
--- a/test/cavs.jl
+++ b/test/cavs.jl
@@ -1,0 +1,98 @@
+# NIST CAVS —— Cryptographic Algorithm Validation Program
+#   Main page:  https://csrc.nist.gov/projects/cryptographic-algorithm-validation-program
+#   Secure-Hashing: https://csrc.nist.gov/Projects/Cryptographic-Algorithm-Validation-Program/Secure-Hashing
+#       SHA1: SHA-1
+#       SHA2: SHA-224 SHA-256 SHA-384 SHA-512 SHA-512/224 SHA-512/256
+#       SHA3: SHA3-224 SHA3-256 SHA3-384 SHA3-512
+#       XOFs: SHAKE128 SHAKE256
+#   Copyrights: https://www.nist.gov/oism/copyrights
+include("cavs_const.jl")
+
+
+"""Generate 100 Monte Carlo test checkpoints for SHA1 and SHA2.
+
+## Code for Generating Pseudorandom Messages
+
+    INPUT: Seed - A random seed n bits long
+    {
+        for (j=0; j<100; j++) {
+            MD0 = MD1 = MD2 = Seed;
+            for (i=3; i<1003; i++) {
+                Mi = MDi-3 || MDi-2 || MDi-1;
+                MDi = SHA(Mi);
+            }
+            MDj = Seed = MD1002;
+            OUTPUT: MDj
+        }
+    }
+
+Note: `||` stand for array concatenate.
+
+xref: Section 6.4
+    https://csrc.nist.gov/CSRC/media/Projects/Cryptographic-Algorithm-Validation-Program/documents/shs/SHAVS.pdf
+"""
+function sha12_monte_carlo_checkpoints(seed_in, seed_len::Int, sha_f::Function)
+    seed = hex2bytes(seed_in)
+    @assert size(seed) == (seed_len,)
+
+    md = Matrix{UInt8}(undef, 100, seed_len)
+    for j in Base.OneTo(100)
+        x = y = z = seed
+        for _ in 1:1000
+            m_i = vcat(x, y, z)  # 60-element Vector{UInt8}
+            md_i = sha_f(m_i)
+            x, y, z = y, z, md_i
+        end
+        md_j = seed = z
+        md[j,:] = md_j
+    end
+    md
+end
+
+function sha12_csvs_msg(sha_f::Function)
+    p = CAVS_TESTSET_12[sha_f]
+    md = sha12_monte_carlo_checkpoints(p.seed, p.seed_len, sha_f)
+    [ bytes2hex(row) for row in eachrow(md) ]
+end
+
+
+"""Generate 100 Monte Carlo test checkpoints for SHA3.
+
+
+## Code for Generating Pseudorandom Messages
+
+    INPUT: A random Seed n bits long
+    {
+        MD0 = Seed;
+        for (j=0; j<100; j++) {
+            for (i=1; i<1001; i++) {
+                Msgi = MDi-1;
+                MDi = SHA3(Msgi);
+            }
+            MD0 = MD1000;
+            OUTPUT: MD0
+        }
+    }
+
+xref: Section 6.2.3
+    https://csrc.nist.gov/CSRC/media/Projects/Cryptographic-Algorithm-Validation-Program/documents/sha3/sha3vs.pdf
+"""
+function sha3_monte_carlo_checkpoints(seed_in, seed_len::Int, sha_f::Function)
+    seed = hex2bytes(seed_in)
+    @assert size(seed) == (seed_len,)
+
+    md = Matrix{UInt8}(undef, 100, seed_len)
+    for j in Base.OneTo(100)
+        for _ in 1:1000
+            seed = sha_f(seed)
+        end
+        md[j,:] = seed
+    end
+    md
+end
+
+function sha3_csvs_msg(sha_f::Function)
+    p = CAVS_TESTSET_3[sha_f]
+    md = sha3_monte_carlo_checkpoints(p.seed, p.seed_len, sha_f)
+    [ bytes2hex(row) for row in eachrow(md) ]
+end

--- a/test/cavs_const.jl
+++ b/test/cavs_const.jl
@@ -1,0 +1,192 @@
+# NIST CAVS —— Cryptographic Algorithm Validation Program
+# Copyrights:   https://www.nist.gov/oism/copyrights
+# Check `cavs.jl` for more information
+
+
+# Note: The original CAVS test set contains the 100 checkpoints.
+#   The following simplified test set contains only 5 checkpoints (0, 1, 19, 59, 99).
+
+# ---- SHA-1/2/3 test vectors
+SHA1_CAVS_VEC = [
+#   (COUNT, MD)
+    (0, "11f5c38b4479d4ad55cb69fadf62de0b036d5163")
+    (1, "5c26de848c21586bec36995809cb02d3677423d9")
+    (19, "23baee80eee052f3263ac26dd12ea6504a5bd234")
+    (59, "b8b3cd6ca1d5b5610e43212f8df75211aaddcf96")
+    (99, "01b7be5b70ef64843a03fdbb3b247a6278d2cbe1")
+]
+
+SHA2_224_CAVS_VEC = [
+    (0, "cd94d7da13c030208b2d0d78fcfe9ea22fa8906df66aa9a1f42afa70")
+    (1, "555846e884633639565d5e0c01dd93ba58edb01ee18e68ccca28f7b8")
+    (19, "18751a765f3b06fc2c9a1888d4bb78b2d2226799a54dba72b5429f25")
+    (59, "3998a213e392978a38016545a59bd435180da66d2b3da373088f406a")
+    (99, "27033d2d89329ba9d2a39c0292552a5f1f945c115d5abf2064e93754")
+]
+
+SHA2_256_CAVS_VEC = [
+    (0, "e93c330ae5447738c8aa85d71a6c80f2a58381d05872d26bdd39f1fcd4f2b788")
+    (1, "2e78f8c8772ea7c9331d41ed3f9cdf27d8f514a99342ee766ee3b8b0d0b121c0")
+    (19, "52519e6319505df7a9aa83778618ec10b78c5771bac50e8d3f59bc815dabfb1f")
+    (59, "ae5a4fdc779d808ba898966c8c14a6c9894107ef3e1d680f6ae37e95cb7e1b67")
+    (99, "6a912ba4188391a78e6f13d88ed2d14e13afce9db6f7dcbf4a48c24f3db02778")
+]
+
+SHA2_384_CAVS_VEC = [
+    (0, "e81b86c49a38feddfd185f71ca7da6732a053ed4a2640d52d27f53f9f76422650b0e93645301ac99f8295d6f820f1035")
+    (1, "1d6bd21713bffd50946a10c39a7742d740e8f271f0c8f643d4c95375094fd9bf29d89ee61a76053f22e44a4b058a64ed")
+    (19, "b9158943803c47678fefafa91c98966aa3dc1fd96f4e86cfdde7ca879dbf9fa9f54b1988a53376f7005df7fd87b1396b")
+    (59, "14e1b1733b16899c4046a604f8e1e777d55649c5357d7d9e3d7a1c395b6275aecf733a598de1d0bfd7eeaa9ecbd7d1e7")
+    (99, "ccde4359f23e64579c5c0380df837ee950928aa82937a2d2ed33d216e707c46d847efa5ca52dcbda551145e164fbd594")
+]
+
+SHA2_512_CAVS_VEC = [
+    (0, "ada69add0071b794463c8806a177326735fa624b68ab7bcab2388b9276c036e4eaaff87333e83c81c0bca0359d4aeebcbcfd314c0630e0c2af68c1fb19cc470e")
+    (1, "ef219b37c24ae507a2b2b26d1add51b31fb5327eb8c3b19b882fe38049433dbeccd63b3d5b99ba2398920bcefb8aca98cd28a1ee5d2aaf139ce58a15d71b06b4")
+    (19, "3d40ccd9cc445bbecca9227c67fe455d89e0b7c1c858d32f30e2b544ca9a5a606535aea2e59fec6ec4d1ba898cc4338c6eadef9c0884bcf56aca2f481a2d7d3e")
+    (59, "2f3d5c5f990bf615d5e8b396ccbd0337da39fad09b059f955a431db76a9dc720dffc4e02c0be397c7e0463799cd75fd6ab7c52bec66c8df5ef0d47e14a4c5927")
+    (99, "4aa7dad74eb51d09a6ae7735c4b795b078f51c314f14f42a0d63071e13bdc5fd9f51612e77b36d44567502a3b5eb66c609ec017e51d8df93e58d1a44f3c1e375")
+]
+
+# SHA2_512_224_CAVS_VEC = [
+#     (0, "")
+#     (1, "")
+#     (19, "")
+#     (59, "")
+#     (99, "")
+# ]
+
+# SHA2_512_256_CAVS_VEC = [
+#     (0, "")
+#     (1, "")
+#     (19, "")
+#     (59, "")
+#     (99, "")
+# ]
+
+SHA3_224_CAVS_VEC = [
+    (0, "90080c037bda5fafcada98e8afda62b10ffb5781b97f6e7aa3ded6e6")
+    (1, "b56de7b4b405b0bdf23ed9c4593956cb4231846f278cd8d8699ab7c0")
+    (19, "76a224d6016e5c010b08e95e58ea013145b776056b12a74786c6ec2b")
+    (59, "b6e3132fba32608d03abce8a9e83613a9f40b0cc43fc730ea627b9ba")
+    (99, "91defbe230b514d7db13d915a82368d32d48f55db31d16e3ae7fbbd0")
+]
+
+SHA3_256_CAVS_VEC = [
+    (0, "225cbac2be6f329d94228c5360a1c177bc495a761c442a1771b1d18555c309a5")
+    (1, "96d364a1b1ced3dbbce6380093fb1ac77221abcee30faf16546ffad8fe1eef8c")
+    (19, "d79a6f3dde5e053f342a2a2a9f844ddac71e5ff468a0d3276c81bd8126b3ee17")
+    (59, "c00ce2788f5ab3d14a492240ea54d05bac108353a2203436d3e0701c1b088262")
+    (99, "456f2ed7f5433bb4e56d7780a21a953e95d6a5eb53bb4c974c57a90e677f3197")
+]
+
+SHA3_384_CAVS_VEC = [
+    (0, "b2d4e10214bd7991e3a3e4772f5c7b390178e20c3ff882648a891e44b9d309d91bf5fab74c0bc155a7fac972a9b128a2")
+    (1, "608db3176176effb7b7cceb8962bffc67584cc9e9860752f6644c7810cc83f4fdefa108bcf308d4137265fbb1ecf10fb")
+    (19, "4f31053aa710a9376fa2a410e3458c1b4d9005c66ae01f41c093996f9a8b5c6885467acd9ad4b4bbbe1fa32d24ace547")
+    (59, "bab50ad626ec56d8dbe9a9318a2fcb2359d0accd9499bd76a8db33922503f40f3b0e9a43af68d537bfac341b343d21d8")
+    (99, "02c9babd4add11a5f23c1808f72e3dc8325cedc31d28213a04d999dac8f46b866f84ba3dbfbcf1a863cc54d808ffadca")
+]
+
+SHA3_512_CAVS_VEC = [
+    (0, "83dd81285c36d86dde72631a1a1e0d9c12b0e2842d499a63b00de87f11839565b21d9416f154b72034b7fcd41d2f1d9eac184eec823547772826ed90c53d856e")
+    (1, "5c37bb6fe060007ce3fca1e6d01ed1bdd6e737f043a2929548cf1b08224a193e03c7314be44a496c8ecaf8a7458770f59cd27336a38ffa40588539572ecb946f")
+    (19, "099d3e5e4fd60468274b7f486f379487786596ac216bde7f095ef4a1617e02223d404cee0dc801175c3dbd02947b37e3a26628b7573f92a6ae26e34eec6800d0")
+    (59, "1c8d7b5a951258e4f2f56a664c79b4b921f2296d360b6cc91eeb5cce08180d6d1ff0296db5ad9a7a4c2f69a5c2fcafa550961115d87713a7da3ccb619ec79733")
+    (99, "760824a439b0681fcd5d22f8467d927a764febc457fd1eb62584ca82b00e1a07905a0117a955041892d2c9d849c096067ed2893aca5c841f8aa32dabe642bc82")
+]
+
+
+# ---- CAVS test metadata
+"""
+Metadata and test vectors came from:
+    SHA*Monte.rsp (CAVS 11.1)
+    FIPS 180-4 - SHA Test Vectors for Hashing Byte-Oriented Messages
+    https://csrc.nist.gov/CSRC/media/Projects/Cryptographic-Algorithm-Validation-Program/documents/shs/shabytetestvectors.zip
+"""
+CAVS_TESTSET_12 = Dict(
+    # SHA-1
+    sha1 => (
+        # test name
+        name = "SHA-1 Monte",
+        # test seed
+        seed = "dd4df644eaf3d85bace2b21accaa22b28821f5cd",
+        # seed length in byte
+        seed_len = 20,
+        # test vector array :: Vector{Tuple{Int64, String}}
+        cavs_vec = SHA1_CAVS_VEC
+    ),
+
+    # SHA-2
+    sha2_224 => (
+        name = "SHA-224 Monte",
+        seed = "ed2b70d575d9d0b4196ae84a03eed940057ea89cdd729b95b7d4e6a5",
+        seed_len = 28,
+        cavs_vec = SHA2_224_CAVS_VEC
+    ),
+    sha2_256 => (
+        name = "SHA-256 Monte",
+        seed = "6d1e72ad03ddeb5de891e572e2396f8da015d899ef0e79503152d6010a3fe691",
+        seed_len = 32,
+        cavs_vec = SHA2_256_CAVS_VEC
+    ),
+    sha2_384 => (
+        name = "SHA-384 Monte",
+        seed = "edff07255c71b54a9beae52cdfa083569a08be89949cbba73ddc8acf429359ca5e5be7a673633ca0d9709848f522a9df",
+        seed_len = 48,
+        cavs_vec = SHA2_384_CAVS_VEC
+    ),
+    sha2_512 => (
+        name = "SHA-512 Monte",
+        seed = "5c337de5caf35d18ed90b5cddfce001ca1b8ee8602f367e7c24ccca6f893802fb1aca7a3dae32dcd60800a59959bc540d63237876b799229ae71a2526fbc52cd",
+        seed_len = 64,
+        cavs_vec = SHA2_512_CAVS_VEC
+    ),
+    # sha2_512_224 => (
+    #     name = "SHA-512/224 Monte",
+    #     seed = "2e325bf8c98c0be54493d04c329e706343aebe4968fdd33b37da9c0a",
+    #     seed_len = 28,
+    #     cavs_vec = SHA2_512_224_CAVS_VEC
+    # ),
+    # sha2_512_256 => (
+    #     name = "SHA-512/256 Monte",
+    #     seed = "f41ece2613e4573915696b5adcd51ca328be3bf566a9ca99c9ceb0279c1cb0a7",
+    #     seed_len = 32,
+    #     cavs_vec = SHA2_512_256_CAVS_VEC
+    # )
+)
+
+
+"""
+Metadata and test vectors came from:
+    SHA3_*Monte.rsp (CAVS 19.0)
+    FIPS 202 - SHA-3 Hash Function Test Vectors for Hashing Byte-Oriented Messages
+    https://csrc.nist.gov/CSRC/media/Projects/Cryptographic-Algorithm-Validation-Program/documents/sha3/sha-3bytetestvectors.zip
+"""
+CAVS_TESTSET_3 = Dict(
+    # SHA-3
+    sha3_224 => (
+        name = "SHA3-224 Monte",
+        seed = "3a9415d401aeb8567e6f0ecee311f4f716b39e86045c8a51383db2b6",
+        seed_len = 28,
+        cavs_vec = SHA3_224_CAVS_VEC
+    ),
+    sha3_256 => (
+        name = "SHA3-256 Monte",
+        seed = "aa64f7245e2177c654eb4de360da8761a516fdc7578c3498c5e582e096b8730c",
+        seed_len = 32,
+        cavs_vec = SHA3_256_CAVS_VEC
+    ),
+    sha3_384 => (
+        name = "SHA3-384 Monte",
+        seed = "7a00791f6f65c21f1c97c58fa3c0520cfc85cd7e3d398cf01950819fa717195065a363e77d07753647cb0c130e9972ad",
+        seed_len = 48,
+        cavs_vec = SHA3_384_CAVS_VEC
+    ),
+    sha3_512 => (
+        name = "SHA3-512 Monte",
+        seed = "764a5511f00dbb0eaef2eb27ad58d35f74f563b88f789ff53f6cf3a47060c75ceb455444cd17b6d438c042e0483919d249f2fd372774647d2545cbfad20b4d31",
+        seed_len = 64,
+        cavs_vec = SHA3_512_CAVS_VEC
+    )
+)

--- a/test/hmac.jl
+++ b/test/hmac.jl
@@ -1,0 +1,81 @@
+# NIST - Cryptographic Standards and Guidelines
+# Examples with Intermediate Values
+#   Message Authentication: https://csrc.nist.gov/projects/cryptographic-standards-and-guidelines/example-values
+# Copyrights:   https://www.nist.gov/oism/copyrights
+
+
+NIST_EXAMPLE_VAL = [
+    # ---- SHA1
+    #   https://csrc.nist.gov/CSRC/media/Projects/Cryptographic-Standards-and-Guidelines/documents/examples/HMAC_SHA1.pdf
+    hmac_sha1 => [
+        (key_len=64,  msg="Sample message for keylen=blocklen", mac="5FD596EE78D5553C8FF4E72D266DFD192366DA29"),
+        (key_len=20,  msg="Sample message for keylen<blocklen", mac="4C99FF0CB1B31BD33F8431DBAF4D17FCD356A807"),
+        (key_len=100, msg="Sample message for keylen=blocklen", mac="2D51B2F7750E410584662E38F133435F4C4FD42A"),
+        (key_len=49,  msg="Sample message for keylen<blocklen, with truncated tag", mac="FE3529565CD8E28C5FA79EAC9D8023B53B289D96")
+    ],
+
+    # ---- SHA2
+    #   https://csrc.nist.gov/CSRC/media/Projects/Cryptographic-Standards-and-Guidelines/documents/examples/HMAC_SHA224.pdf
+    #   https://csrc.nist.gov/CSRC/media/Projects/Cryptographic-Standards-and-Guidelines/documents/examples/HMAC_SHA256.pdf
+    #   https://csrc.nist.gov/CSRC/media/Projects/Cryptographic-Standards-and-Guidelines/documents/examples/HMAC_SHA384.pdf
+    #   https://csrc.nist.gov/CSRC/media/Projects/Cryptographic-Standards-and-Guidelines/documents/examples/HMAC_SHA512.pdf
+    hmac_sha2_224 => [
+        (key_len=64,  msg="Sample message for keylen=blocklen", mac="C7405E3AE058E8CD30B08B4140248581ED174CB34E1224BCC1EFC81B"),
+        (key_len=28,  msg="Sample message for keylen<blocklen", mac="E3D249A8CFB67EF8B7A169E9A0A599714A2CECBA65999A51BEB8FBBE"),
+        (key_len=100, msg="Sample message for keylen=blocklen", mac="91C52509E5AF8531601AE6230099D90BEF88AAEFB961F4080ABC014D"),
+        (key_len=49,  msg="Sample message for keylen<blocklen, with truncated tag", mac="D522F1DF596CA4B4B1C23D27BDE067D6153BA9725FD5CDE0AF4A2A42")
+    ],
+    hmac_sha2_256 => [
+        (key_len=64,  msg="Sample message for keylen=blocklen", mac="8BB9A1DB9806F20DF7F77B82138C7914D174D59E13DC4D0169C9057B133E1D62"),
+        (key_len=32,  msg="Sample message for keylen<blocklen", mac="A28CF43130EE696A98F14A37678B56BCFCBDD9E5CF69717FECF5480F0EBDF790"),
+        (key_len=100, msg="Sample message for keylen=blocklen", mac="BDCCB6C72DDEADB500AE768386CB38CC41C63DBB0878DDB9C7A38A431B78378D"),
+        (key_len=49,  msg="Sample message for keylen<blocklen, with truncated tag", mac="27A8B157839EFEAC98DF070B331D593618DDB985D403C0C786D23B5D132E57C7")
+    ],
+    hmac_sha2_384 => [
+        (key_len=128, msg="Sample message for keylen=blocklen", mac="63C5DAA5E651847CA897C95814AB830BEDEDC7D25E83EEF9195CD45857A37F448947858F5AF50CC2B1B730DDF29671A9"),
+        (key_len=48,  msg="Sample message for keylen<blocklen", mac="6EB242BDBB582CA17BEBFA481B1E23211464D2B7F8C20B9FF2201637B93646AF5AE9AC316E98DB45D9CAE773675EEED0"),
+        (key_len=200, msg="Sample message for keylen=blocklen", mac="5B664436DF69B0CA22551231A3F0A3D5B4F97991713CFA84BFF4D0792EFF96C27DCCBBB6F79B65D548B40E8564CEF594"),
+        (key_len=49,  msg="Sample message for keylen<blocklen, with truncated tag", mac="C48130D3DF703DD7CDAA56800DFBD2BA2458320E6E1F98FEC8AD9F57F43800DF3615CEB19AB648E1ECDD8C730AF95C8A")
+    ],
+    hmac_sha2_512 => [
+        (key_len=128, msg="Sample message for keylen=blocklen", mac="FC25E240658CA785B7A811A8D3F7B4CA48CFA26A8A366BF2CD1F836B05FCB024BD36853081811D6CEA4216EBAD79DA1CFCB95EA4586B8A0CE356596A55FB1347"),
+        (key_len=64,  msg="Sample message for keylen<blocklen", mac="FD44C18BDA0BB0A6CE0E82B031BF2818F6539BD56EC00BDC10A8A2D730B3634DE2545D639B0F2CF710D0692C72A1896F1F211C2B922D1A96C392E07E7EA9FEDC"),
+        (key_len=200, msg="Sample message for keylen=blocklen", mac="D93EC8D2DE1AD2A9957CB9B83F14E76AD6B5E0CCE285079A127D3B14BCCB7AA7286D4AC0D4CE64215F2BC9E6870B33D97438BE4AAA20CDA5C5A912B48B8E27F3"),
+        (key_len=49,  msg="Sample message for keylen<blocklen, with truncated tag", mac="00F3E9A77BB0F06DE15F160603E42B5028758808596664C03E1AB8FB2B0767780563AEDC644960D4F0C0C5D239F67A2A61B141E8C871F3D40DB2C605588DAB92")
+    ],
+
+    # ---- SHA3
+    #   https://csrc.nist.gov/CSRC/media/Projects/Cryptographic-Standards-and-Guidelines/documents/examples/HMAC_SHA3-224.pdf
+    #   https://csrc.nist.gov/CSRC/media/Projects/Cryptographic-Standards-and-Guidelines/documents/examples/HMAC_SHA3-256.pdf
+    #   https://csrc.nist.gov/CSRC/media/Projects/Cryptographic-Standards-and-Guidelines/documents/examples/HMAC_SHA3-384.pdf
+    #   https://csrc.nist.gov/CSRC/media/Projects/Cryptographic-Standards-and-Guidelines/documents/examples/HMAC_SHA3-512.pdf
+    hmac_sha3_224 => [
+        (key_len=28,  msg="Sample message for keylen<blocklen", mac="332cfd59347fdb8e576e77260be4aba2d6dc53117b3bfb52c6d18c04"),
+        (key_len=144, msg="Sample message for keylen=blocklen", mac="d8b733bcf66c644a12323d564e24dcf3fc75f231f3b67968359100c7"),
+        (key_len=172, msg="Sample message for keylen>blocklen", mac="078695eecc227c636ad31d063a15dd05a7e819a66ec6d8de1e193e59"),
+        (key_len=28,  msg="Sample message for keylen<blocklen, with truncated tag", mac="8569c54cbb00a9b78ff1b391b0e5cd2fa5ec728550aa3979703305d4")
+    ],
+    hmac_sha3_256 => [
+        (key_len=32,  msg="Sample message for keylen<blocklen", mac="4fe8e202c4f058e8dddc23d8c34e467343e23555e24fc2f025d598f558f67205"),
+        (key_len=136, msg="Sample message for keylen=blocklen", mac="68b94e2e538a9be4103bebb5aa016d47961d4d1aa906061313b557f8af2c3faa"),
+        (key_len=168, msg="Sample message for keylen>blocklen", mac="9bcf2c238e235c3ce88404e813bd2f3a97185ac6f238c63d6229a00b07974258"),
+        (key_len=32,  msg="Sample message for keylen<blocklen, with truncated tag", mac="c8dc7148d8c1423aa549105dafdf9cad2941471b5c62207088e56ccf2dd80545")
+    ],
+    hmac_sha3_384 => [
+        (key_len=48,  msg="Sample message for keylen<blocklen", mac="d588a3c51f3f2d906e8298c1199aa8ff6296218127f6b38a90b6afe2c5617725bc99987f79b22a557b6520db710b7f42"),
+        (key_len=104, msg="Sample message for keylen=blocklen", mac="a27d24b592e8c8cbf6d4ce6fc5bf62d8fc98bf2d486640d9eb8099e24047837f5f3bffbe92dcce90b4ed5b1e7e44fa90"),
+        (key_len=152, msg="Sample message for keylen>blocklen", mac="e5ae4c739f455279368ebf36d4f5354c95aa184c899d3870e460ebc288ef1f9470053f73f7c6da2a71bcaec38ce7d6ac"),
+        (key_len=48,  msg="Sample message for keylen<blocklen, with truncated tag", mac="25f4bf53606e91af79d24a4bb1fd6aecd44414a30c8ebb0ae09764c71aceefe8dfa72309e48152c98294be658a33836e")
+    ],
+    hmac_sha3_512 => [
+        (key_len=64,  msg="Sample message for keylen<blocklen", mac="4efd629d6c71bf86162658f29943b1c308ce27cdfa6db0d9c3ce81763f9cbce5f7ebe9868031db1a8f8eb7b6b95e5c5e3f657a8996c86a2f6527e307f0213196"),
+        (key_len=72,  msg="Sample message for keylen=blocklen", mac="544e257ea2a3e5ea19a590e6a24b724ce6327757723fe2751b75bf007d80f6b360744bf1b7a88ea585f9765b47911976d3191cf83c039f5ffab0d29cc9d9b6da"),
+        (key_len=136, msg="Sample message for keylen>blocklen", mac="5f464f5e5b7848e3885e49b2c385f0694985d0e38966242dc4a5fe3fea4b37d46b65ceced5dcf59438dd840bab22269f0ba7febdb9fcf74602a35666b2a32915"),
+        (key_len=64,  msg="Sample message for keylen<blocklen, with truncated tag", mac="7bb06d859257b25ce73ca700df34c5cbef5c898bac91029e0b27975d4e526a088f5e590ee736969f445643a58bee7ee0cbbbb2e14775584435d36ad0de6b9499")
+    ]
+]
+
+
+function key_gen(len::Int)
+    UnitRange{UInt8}(0, len-1) |> collect
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,8 @@
 using SHA, Test
 
 include("constants.jl")
+include("cavs.jl")
+
 
 function describe_hash(T::Type{S}) where {S <: SHA.SHA_CTX}
     if T <: SHA.SHA1_CTX return "SHA1" end
@@ -19,6 +21,28 @@ end
                     sha_func = sha_funcs[sha_idx]
                     hash = bytes2hex(sha_func(deepcopy(data[idx])))
                     @test hash == answers[sha_func][idx]
+                end
+            end
+        end
+    end
+
+    @testset "NIST CAVS Test for SHA1/2" begin
+        for (sha_func, p) in CAVS_TESTSET_12
+            hash = sha12_csvs_msg(sha_func)
+            @testset "$(p.name)" begin
+                for (idx, val) in p.cavs_vec
+                    @test hash[idx+1] == val
+                end
+            end
+        end
+    end
+
+    @testset "NIST CAVS Test for SHA3" begin
+        for (sha_func, p) in CAVS_TESTSET_3
+            hash = sha3_csvs_msg(sha_func)
+            @testset "$(p.name)" begin
+                for (idx, val) in p.cavs_vec
+                    @test hash[idx+1] == val
                 end
             end
         end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,6 +2,7 @@ using SHA, Test
 
 include("constants.jl")
 include("cavs.jl")
+include("hmac.jl")
 
 
 function describe_hash(T::Type{S}) where {S <: SHA.SHA_CTX}
@@ -97,6 +98,16 @@ end
         @test digest == hash
         digest = bytes2hex(fun(Vector{UInt8}(key), IOBuffer(msg)))
         @test digest == hash
+    end
+
+    @testset "NIST example values test" begin
+        for (sha_func, test) in NIST_EXAMPLE_VAL
+            @testset "$(sha_func)" begin
+                for (key_len, msg, mac) in test
+                    @test sha_func(key_gen(key_len), msg) |> bytes2hex == lowercase.(mac)
+                end
+            end
+        end
     end
 end
 


### PR DESCRIPTION
## NIST CAVS SHA random test

https://csrc.nist.gov/Projects/Cryptographic-Algorithm-Validation-Program/Secure-Hashing

Test all SHA1/2/3 functions;

Using a method similar to a pseudo-random number generator, 
+ select a seed (input)
+ constructing an input message according to certain rules
+ calculate hash

*next cycle*
+ reconstructing the message
+ calculate hash again
+ goto next cycle


Each function is sampled once for every 1000 calculations, for a total of 100 samples.
For simplicity, only five of these 100 samples are tested.

## NIST HMAC test examples

"Message Authentication" section: https://csrc.nist.gov/projects/cryptographic-standards-and-guidelines/example-values

NIST constructed 4 test cases for each hmac function:

The test samples include the following three cases:
+ keylen < blocklen
+ keylen == blocklen
+ keylen > blocklen