### PR TITLE
Switch info for debug log

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -8,7 +8,7 @@ function describe_hash(T::Type{S}) where {S <: SHA.SHA_CTX}
     if T <: SHA.SHA3_CTX return "SHA3-$(SHA.digestlen(T)*8)" end
 end
 
-@info("Loaded hash types: $(join(sort([describe_hash(t[2]) for t in sha_types]), ", ", " and "))")
+@debug("Loaded hash types: $(join(sort([describe_hash(t[2]) for t in sha_types]), ", ", " and "))")
 
 @testset "Hashing" begin
     # First, test processing the data in one go


### PR DESCRIPTION
As part of making tests less noisy https://github.com/JuliaLang/julia/pull/44444 I saw that this info line always shows in Base tests. Perhaps it could become a debug?

@staticfloat

