### PR TITLE
Protect against re-using digested context

### DIFF
--- a/src/types.jl
+++ b/src/types.jl
@@ -12,6 +12,7 @@ mutable struct SHA1_CTX <: SHA_CTX
     bytecount::UInt64
     buffer::Array{UInt8,1}
     W::Array{UInt32,1}
+    used::Bool
 end
 
 # SHA2 224/256/384/512-bit Context Structures
@@ -19,24 +20,28 @@ mutable struct SHA2_224_CTX <: SHA2_CTX
     state::Array{UInt32,1}
     bytecount::UInt64
     buffer::Array{UInt8,1}
+    used::Bool
 end
 
 mutable struct SHA2_256_CTX <: SHA2_CTX
     state::Array{UInt32,1}
     bytecount::UInt64
     buffer::Array{UInt8,1}
+    used::Bool
 end
 
 mutable struct SHA2_384_CTX <: SHA2_CTX
     state::Array{UInt64,1}
     bytecount::UInt128
     buffer::Array{UInt8,1}
+    used::Bool
 end
 
 mutable struct SHA2_512_CTX <: SHA2_CTX
     state::Array{UInt64,1}
     bytecount::UInt128
     buffer::Array{UInt8,1}
+    used::Bool
 end
 
 function Base.getproperty(ctx::SHA2_CTX, fieldname::Symbol)
@@ -48,6 +53,8 @@ function Base.getproperty(ctx::SHA2_CTX, fieldname::Symbol)
         return getfield(ctx, :buffer)::Vector{UInt8}
     elseif fieldname === :W
         return getfield(ctx, :W)::Vector{UInt32}
+    elseif fieldname === :used
+        return getfield(ctx, :used)::Bool
     else
         error("SHA2_CTX has no field ", fieldname)
     end
@@ -67,24 +74,28 @@ mutable struct SHA3_224_CTX <: SHA3_CTX
     bytecount::UInt128
     buffer::Array{UInt8,1}
     bc::Array{UInt64,1}
+    used::Bool
 end
 mutable struct SHA3_256_CTX <: SHA3_CTX
     state::Array{UInt64,1}
     bytecount::UInt128
     buffer::Array{UInt8,1}
     bc::Array{UInt64,1}
+    used::Bool
 end
 mutable struct SHA3_384_CTX <: SHA3_CTX
     state::Array{UInt64,1}
     bytecount::UInt128
     buffer::Array{UInt8,1}
     bc::Array{UInt64,1}
+    used::Bool
 end
 mutable struct SHA3_512_CTX <: SHA3_CTX
     state::Array{UInt64,1}
     bytecount::UInt128
     buffer::Array{UInt8,1}
     bc::Array{UInt64,1}
+    used::Bool
 end
 
 function Base.getproperty(ctx::SHA3_CTX, fieldname::Symbol)
@@ -96,6 +107,8 @@ function Base.getproperty(ctx::SHA3_CTX, fieldname::Symbol)
         return getfield(ctx, :buffer)::Vector{UInt8}
     elseif fieldname === :bc
         return getfield(ctx, :bc)::Vector{UInt64}
+    elseif fieldname === :used
+        return getfield(ctx, :used)::Bool
     else
         error("type ", typeof(ctx), " has no field ", fieldname)
     end
@@ -145,50 +158,50 @@ short_blocklen(::Type{T}) where {T<:SHA_CTX} = blocklen(T) - 2*sizeof(state_type
 
 Construct an empty SHA2_224 context.
 """
-SHA2_224_CTX() = SHA2_224_CTX(copy(SHA2_224_initial_hash_value), 0, zeros(UInt8, blocklen(SHA2_224_CTX)))
+SHA2_224_CTX() = SHA2_224_CTX(copy(SHA2_224_initial_hash_value), 0, zeros(UInt8, blocklen(SHA2_224_CTX)), false)
 """
     SHA2_256_CTX()
 
 Construct an empty SHA2_256 context.
 """
-SHA2_256_CTX() = SHA2_256_CTX(copy(SHA2_256_initial_hash_value), 0, zeros(UInt8, blocklen(SHA2_256_CTX)))
+SHA2_256_CTX() = SHA2_256_CTX(copy(SHA2_256_initial_hash_value), 0, zeros(UInt8, blocklen(SHA2_256_CTX)), false)
 """
     SHA2_384()
 
 Construct an empty SHA2_384 context.
 """
-SHA2_384_CTX() = SHA2_384_CTX(copy(SHA2_384_initial_hash_value), 0, zeros(UInt8, blocklen(SHA2_384_CTX)))
+SHA2_384_CTX() = SHA2_384_CTX(copy(SHA2_384_initial_hash_value), 0, zeros(UInt8, blocklen(SHA2_384_CTX)), false)
 """
     SHA2_512_CTX()
 
 Construct an empty SHA2_512 context.
 """
-SHA2_512_CTX() = SHA2_512_CTX(copy(SHA2_512_initial_hash_value), 0, zeros(UInt8, blocklen(SHA2_512_CTX)))
+SHA2_512_CTX() = SHA2_512_CTX(copy(SHA2_512_initial_hash_value), 0, zeros(UInt8, blocklen(SHA2_512_CTX)), false)
 
 """
     SHA3_224_CTX()
 
 Construct an empty SHA3_224 context.
 """
-SHA3_224_CTX() = SHA3_224_CTX(zeros(UInt64, 25), 0, zeros(UInt8, blocklen(SHA3_224_CTX)), Vector{UInt64}(undef, 5))
+SHA3_224_CTX() = SHA3_224_CTX(zeros(UInt64, 25), 0, zeros(UInt8, blocklen(SHA3_224_CTX)), Vector{UInt64}(undef, 5), false)
 """
     SHA3_256_CTX()
 
 Construct an empty SHA3_256 context.
 """
-SHA3_256_CTX() = SHA3_256_CTX(zeros(UInt64, 25), 0, zeros(UInt8, blocklen(SHA3_256_CTX)), Vector{UInt64}(undef, 5))
+SHA3_256_CTX() = SHA3_256_CTX(zeros(UInt64, 25), 0, zeros(UInt8, blocklen(SHA3_256_CTX)), Vector{UInt64}(undef, 5), false)
 """
     SHA3_384_CTX()
 
 Construct an empty SHA3_384 context.
 """
-SHA3_384_CTX() = SHA3_384_CTX(zeros(UInt64, 25), 0, zeros(UInt8, blocklen(SHA3_384_CTX)), Vector{UInt64}(undef, 5))
+SHA3_384_CTX() = SHA3_384_CTX(zeros(UInt64, 25), 0, zeros(UInt8, blocklen(SHA3_384_CTX)), Vector{UInt64}(undef, 5), false)
 """
     SHA3_512_CTX()
 
 Construct an empty SHA3_512 context.
 """
-SHA3_512_CTX() = SHA3_512_CTX(zeros(UInt64, 25), 0, zeros(UInt8, blocklen(SHA3_512_CTX)), Vector{UInt64}(undef, 5))
+SHA3_512_CTX() = SHA3_512_CTX(zeros(UInt64, 25), 0, zeros(UInt8, blocklen(SHA3_512_CTX)), Vector{UInt64}(undef, 5), false)
 
 # Nickname'd outer constructor methods for SHA2
 const SHA224_CTX = SHA2_224_CTX
@@ -202,13 +215,13 @@ const SHA512_CTX = SHA2_512_CTX
 
 Construct an empty SHA1 context.
 """
-SHA1_CTX() = SHA1_CTX(copy(SHA1_initial_hash_value), 0, zeros(UInt8, blocklen(SHA1_CTX)), Vector{UInt32}(undef, 80))
+SHA1_CTX() = SHA1_CTX(copy(SHA1_initial_hash_value), 0, zeros(UInt8, blocklen(SHA1_CTX)), Vector{UInt32}(undef, 80), false)
 
 
 # Copy functions
-copy(ctx::T) where {T<:SHA1_CTX} = T(copy(ctx.state), ctx.bytecount, copy(ctx.buffer), copy(ctx.W))
-copy(ctx::T) where {T<:SHA2_CTX} = T(copy(ctx.state), ctx.bytecount, copy(ctx.buffer))
-copy(ctx::T) where {T<:SHA3_CTX} = T(copy(ctx.state), ctx.bytecount, copy(ctx.buffer), Vector{UInt64}(undef, 5))
+copy(ctx::T) where {T<:SHA1_CTX} = T(copy(ctx.state), ctx.bytecount, copy(ctx.buffer), copy(ctx.W), ctx.used)
+copy(ctx::T) where {T<:SHA2_CTX} = T(copy(ctx.state), ctx.bytecount, copy(ctx.buffer), ctx.used)
+copy(ctx::T) where {T<:SHA3_CTX} = T(copy(ctx.state), ctx.bytecount, copy(ctx.buffer), Vector{UInt64}(undef, 5), ctx.used)
 
 
 # Make printing these types a little friendlier

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -63,6 +63,23 @@ end
             @test hash == answers[sha_funcs[sha_idx]][end]
         end
     end
+
+    # Test that the hash states cannot be updated after having been finalized,
+    # but can still return the same digest
+    @testset "Reuse" begin
+        for sha_idx in 1:length(sha_funcs)
+            ctx = sha_types[sha_funcs[sha_idx]]()
+            update!(ctx, codeunits("abracadabra"))
+            hash1 = digest!(ctx)
+
+            # Cannot update after having been digested
+            @test_throws Exception update!(ctx, codeunits("abc"))
+
+            # But will still return the same digest twice
+            hash2 = digest!(ctx)
+            @test hash1 == hash2
+        end
+    end
 end
 
 @testset "HMAC" begin


### PR DESCRIPTION
Prevent users from calling `update!` on a context that has already been finalized, and warn against doing this in the docstring of `digest!`

If storing a `Bool` in the structs is too wasteful (8-bytes alignment and all), we can use the top bit of the `bytecount` field instead. Let me know if you think this optimisation is worth the additional implementation complexity.

Closes #85 