### PR TITLE
Hardcode doc edit backlink

### DIFF
--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -1,3 +1,7 @@
+```@meta
+EditURL = "https://github.com/JuliaCrypto/SHA.jl/blob/master/docs/src/index.md"
+```
+
 # SHA
 
 ```@meta


### PR DESCRIPTION
@staticfloat, currently, the "Edit on Github" link at https://docs.julialang.org/en/v1/stdlib/SHA/ is broken (JuliaLang/julia#50035). This PR fixes that link. See also: JuliaLang/julia#51375