### PR TITLE
shake128,shake256: fixed typo in export declarations

### DIFF
--- a/src/SHA.jl
+++ b/src/SHA.jl
@@ -77,7 +77,7 @@ for (f, ctx) in [(:sha1, :SHA1_CTX),
                  (:sha3_224, :SHA3_224_CTX),
                  (:sha3_256, :SHA3_256_CTX),
                  (:sha3_384, :SHA3_384_CTX),
-                 (:sha3_512, :SHA3_512_CTX),]
+                 (:sha3_512, :SHA3_512_CTX)]
     g = Symbol(:hmac_, f)
 
     @eval begin

--- a/src/SHA.jl
+++ b/src/SHA.jl
@@ -38,7 +38,7 @@ export sha1, SHA1_CTX, update!, digest!
 export sha224, sha256, sha384, sha512
 export sha2_224, sha2_256, sha2_384, sha2_512
 export sha3_224, sha3_256, sha3_384, sha3_512
-export shake_128, shake_256
+export shake128, shake256
 export SHA224_CTX, SHA256_CTX, SHA384_CTX, SHA512_CTX
 export SHA2_224_CTX, SHA2_256_CTX, SHA2_384_CTX, SHA2_512_CTX
 export SHA3_224_CTX, SHA3_256_CTX, SHA3_384_CTX, SHA3_512_CTX
@@ -77,8 +77,7 @@ for (f, ctx) in [(:sha1, :SHA1_CTX),
                  (:sha3_224, :SHA3_224_CTX),
                  (:sha3_256, :SHA3_256_CTX),
                  (:sha3_384, :SHA3_384_CTX),
-                 (:sha3_512, :SHA3_512_CTX),
-                 (:shake_256, :SHAKE_256_CTX),]
+                 (:sha3_512, :SHA3_512_CTX),]
     g = Symbol(:hmac_, f)
 
     @eval begin


### PR DESCRIPTION
Hi @staticfloat 

I updated my SHA Pkg and wanted to start using shake. So i noticed, i did a flaw in the export descriptions, which did not match to the function names in the shake.jl and the tests.

But these small changes should fix it. Sorry for the mess.

