### PR TITLE
Issue #94 (shake128 test coverage): fixed bug in padding for shake, added testcases for full code coverage

### DIFF
--- a/src/shake.jl
+++ b/src/shake.jl
@@ -82,10 +82,7 @@ function digest!(context::T,d::UInt,p::Ptr{UInt8}) where {T<:SHAKE}
         context.buffer[end] = 0x80
     else
         # Otherwise, we have to add on a whole new buffer
-        context.buffer[end] = 0x1f
-        transform!(context)
-        context.buffer[1:end-1] .= 0x0
-        context.buffer[end] = 0x80
+        context.buffer[end] = 0x9f
     end
     # Final transform:
     transform!(context)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -164,6 +164,7 @@ end
             @test SHA.shake128(hex2bytes(k[1]),k[2]) == hex2bytes(v)
         end
         @test SHA.shake128(b"",UInt(16)) == hex2bytes("7f9c2ba4e88f827d616045507605853e")
+        @test SHA.shake128(codeunits("0" ^ 167), UInt(32)) == hex2bytes("ff60b0516fb8a3d4032900976e98b5595f57e9d4a88a0e37f7cc5adfa3c47da2")
     end
 
     @testset "shake256" begin
@@ -171,6 +172,7 @@ end
             @test SHA.shake256(hex2bytes(k[1]),k[2]) == hex2bytes(v)
         end
         @test SHA.shake256(b"",UInt(32)) == hex2bytes("46b9dd2b0ba88d13233b3feb743eeb243fcd52ea62b81b82b50c27646ed5762f")
+        @test SHA.shake256(codeunits("0"^135),UInt(32)) == hex2bytes("ab11f61b5085a108a58670a66738ea7a8d8ce23b7c57d64de83eaafb10923cf8")
     end
     @time SHA.shake256(b"abc",UInt(100000))
     @time SHA.shake128(b"abc",UInt(100000))


### PR DESCRIPTION
Hi @staticfloat  
@inkydragon  mentioned a bug in some lines missed by the Code-Coverage.
There was a bug in the Padding, which differs from SHA3. 
I added new tests, which covers the lines and changed the padding.



