### PR TITLE
Use `Vector` instead of `Array` to simplify types.

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ julia> bytes2hex(sha256("test"))
 "9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08"
 ```
 
-Each exported function (at the time of this writing, SHA-1, SHA-2 224, 256, 384 and 512, and SHA-3 224, 256, 384 and 512 functions are implemented) takes in either an `Array{UInt8}`, a `ByteString` or an `IO` object.  This makes it trivial to checksum a file:
+Each exported function (at the time of this writing, SHA-1, SHA-2 224, 256, 384 and 512, and SHA-3 224, 256, 384 and 512 functions are implemented) takes in either an `Vector{UInt8}`, a `ByteString` or an `IO` object.  This makes it trivial to checksum a file:
 
 ```julia
 shell> cat /tmp/test.txt
@@ -29,7 +29,7 @@ julia> using SHA
 julia> open("/tmp/test.txt") do f
            sha2_256(f)
        end
-32-element Array{UInt8,1}:
+32-element Vector{UInt8}:
  0x9f
  0x86
  0xd0
@@ -52,6 +52,6 @@ Note the lack of a newline at the end of `/tmp/text.txt`.  Julia automatically i
 
 Due to the colloquial usage of `sha256` to refer to `sha2_256`, convenience functions are provided, mapping `shaxxx()` function calls to `sha2_xxx()`.  For SHA-3, no such colloquialisms exist and the user must use the full `sha3_xxx()` names.
 
-`shaxxx()` takes `AbstractString` and array-like objects (`NTuple` and `Array`) with elements of type `UInt8`.
+`shaxxx()` takes `AbstractString` and array-like objects (`NTuple` and `Vector`) with elements of type `UInt8`.
 
 Note that, at the time of this writing, the SHA3 code is not optimized, and as such is roughly an order of magnitude slower than SHA2.  Pull requests are welcome.

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -32,7 +32,7 @@ julia> using SHA
 julia> open("/tmp/test.txt") do f
            sha2_256(f)
        end
-32-element Array{UInt8,1}:
+32-element Vector{UInt8}:
  0x9f
  0x86
  0xd0
@@ -55,7 +55,7 @@ julia> open("/tmp/test.txt") do f
 Due to the colloquial usage of `sha256` to refer to `sha2_256`, convenience functions are provided, mapping `shaxxx()` function calls to `sha2_xxx()`.
 For SHA-3, no such colloquialisms exist and the user must use the full `sha3_xxx()` names.
 
-`shaxxx()` takes `AbstractString` and array-like objects (`NTuple` and `Array`) with elements of type `UInt8`.
+`shaxxx()` takes `AbstractString` and array-like objects (`NTuple` and `Vector`) with elements of type `UInt8`.
 
 **SHA-1**
 ```@docs

--- a/src/common.jl
+++ b/src/common.jl
@@ -82,7 +82,7 @@ end
 """
     digest!(context)
 
-Finalize the SHA context and return the hash as array of bytes (Array{Uint8, 1}).
+Finalize the SHA context and return the hash as array of bytes (Vector{Uint8}).
 Updating the context after calling `digest!` on it will error.
 
 # Examples
@@ -93,7 +93,7 @@ SHA1 hash state
 julia> update!(ctx, b"data to to be hashed")
 
 julia> digest!(ctx)
-20-element Array{UInt8,1}:
+20-element Vector{UInt8}:
  0x83
  0xe4
  ⋮

--- a/src/shake.jl
+++ b/src/shake.jl
@@ -1,17 +1,17 @@
 abstract type SHAKE <: SHA3_CTX end 
 # note, that field property used has differend uses, depending on T<:SHAKE or T<:SHA3_CTX
 mutable struct SHAKE_128_CTX <: SHAKE
-    state::Array{UInt64,1}
+    state::Vector{UInt64}
     bytecount::UInt128
-    buffer::Array{UInt8,1}
-    bc::Array{UInt64,1}
+    buffer::Vector{UInt8}
+    bc::Vector{UInt64}
     used::Bool
 end
 mutable struct SHAKE_256_CTX <: SHAKE
-    state::Array{UInt64,1}
+    state::Vector{UInt64}
     bytecount::UInt128
-    buffer::Array{UInt8,1}
-    bc::Array{UInt64,1}
+    buffer::Vector{UInt8}
+    bc::Vector{UInt64}
     used::Bool
 end
 
@@ -111,7 +111,7 @@ Hash data using the `shake128` algorithm and return the first d resulting bytes.
 function shake128(data::AbstractBytes,d::UInt)
     ctx = SHAKE_128_CTX()
     update!(ctx, data)
-    M = Array{UInt8,1}(undef,d)     # prealloc
+    M = Vector{UInt8}(undef,d)     # prealloc
     p = pointer(M)
     digest!(ctx,d,p)
     return M
@@ -124,7 +124,7 @@ Hash data using the `shake258` algorithm and return the first d resulting bytes.
 function shake256(data::AbstractBytes,d::UInt)
     ctx = SHAKE_256_CTX()
     update!(ctx, data)
-    M = Array{UInt8,1}(undef,d)     # prealloc
+    M = Vector{UInt8}(undef,d)     # prealloc
     p = pointer(M)
     digest!(ctx,d,p)
     return M

--- a/src/types.jl
+++ b/src/types.jl
@@ -8,39 +8,39 @@ import Base: copy
 # We derive SHA1_CTX straight from SHA_CTX since it doesn't have a
 # family of types like SHA2 or SHA3 do
 mutable struct SHA1_CTX <: SHA_CTX
-    state::Array{UInt32,1}
+    state::Vector{UInt32}
     bytecount::UInt64
-    buffer::Array{UInt8,1}
-    W::Array{UInt32,1}
+    buffer::Vector{UInt8}
+    W::Vector{UInt32}
     used::Bool
 end
 
 # SHA2 224/256/384/512-bit Context Structures
 mutable struct SHA2_224_CTX <: SHA2_CTX
-    state::Array{UInt32,1}
+    state::Vector{UInt32}
     bytecount::UInt64
-    buffer::Array{UInt8,1}
+    buffer::Vector{UInt8}
     used::Bool
 end
 
 mutable struct SHA2_256_CTX <: SHA2_CTX
-    state::Array{UInt32,1}
+    state::Vector{UInt32}
     bytecount::UInt64
-    buffer::Array{UInt8,1}
+    buffer::Vector{UInt8}
     used::Bool
 end
 
 mutable struct SHA2_384_CTX <: SHA2_CTX
-    state::Array{UInt64,1}
+    state::Vector{UInt64}
     bytecount::UInt128
-    buffer::Array{UInt8,1}
+    buffer::Vector{UInt8}
     used::Bool
 end
 
 mutable struct SHA2_512_CTX <: SHA2_CTX
-    state::Array{UInt64,1}
+    state::Vector{UInt64}
     bytecount::UInt128
-    buffer::Array{UInt8,1}
+    buffer::Vector{UInt8}
     used::Bool
 end
 
@@ -68,31 +68,31 @@ const SHA512_CTX = SHA2_512_CTX
 
 # SHA3 224/256/384/512-bit context structures
 mutable struct SHA3_224_CTX <: SHA3_CTX
-    state::Array{UInt64,1}
+    state::Vector{UInt64}
     bytecount::UInt128
-    buffer::Array{UInt8,1}
-    bc::Array{UInt64,1}
+    buffer::Vector{UInt8}
+    bc::Vector{UInt64}
     used::Bool
 end
 mutable struct SHA3_256_CTX <: SHA3_CTX
-    state::Array{UInt64,1}
+    state::Vector{UInt64}
     bytecount::UInt128
-    buffer::Array{UInt8,1}
-    bc::Array{UInt64,1}
+    buffer::Vector{UInt8}
+    bc::Vector{UInt64}
     used::Bool
 end
 mutable struct SHA3_384_CTX <: SHA3_CTX
-    state::Array{UInt64,1}
+    state::Vector{UInt64}
     bytecount::UInt128
-    buffer::Array{UInt8,1}
-    bc::Array{UInt64,1}
+    buffer::Vector{UInt8}
+    bc::Vector{UInt64}
     used::Bool
 end
 mutable struct SHA3_512_CTX <: SHA3_CTX
-    state::Array{UInt64,1}
+    state::Vector{UInt64}
     bytecount::UInt128
-    buffer::Array{UInt8,1}
-    bc::Array{UInt64,1}
+    buffer::Vector{UInt8}
+    bc::Vector{UInt64}
     used::Bool
 end
 


### PR DESCRIPTION
At least for the docstring and examples this reduces user confusion.
