### PR TITLE
Remvoe all getproperty funcs

### DIFF
--- a/src/types.jl
+++ b/src/types.jl
@@ -58,20 +58,6 @@ mutable struct SHA2_512_256_CTX <: SHA2_CTX
     used::Bool
 end
 
-function Base.getproperty(ctx::SHA2_CTX, fieldname::Symbol)
-    if fieldname === :state
-        return getfield(ctx, :state)::Union{Vector{UInt32},Vector{UInt64}}
-    elseif fieldname === :bytecount
-        return getfield(ctx, :bytecount)::Union{UInt64,UInt128}
-    elseif fieldname === :buffer
-        return getfield(ctx, :buffer)::Vector{UInt8}
-    elseif fieldname === :used
-        return getfield(ctx, :used)::Bool
-    else
-        error("type ", typeof(ctx), " has no field ", fieldname)
-    end
-end
-
 
 # Typealias common nicknames for SHA2 family of functions
 const SHA224_CTX = SHA2_224_CTX
@@ -109,22 +95,6 @@ mutable struct SHA3_512_CTX <: SHA3_CTX
     buffer::Vector{UInt8}
     bc::Vector{UInt64}
     used::Bool
-end
-
-function Base.getproperty(ctx::SHA3_CTX, fieldname::Symbol)
-    if fieldname === :state
-        return getfield(ctx, :state)::Vector{UInt64}
-    elseif fieldname === :bytecount
-        return getfield(ctx, :bytecount)::UInt128
-    elseif fieldname === :buffer
-        return getfield(ctx, :buffer)::Vector{UInt8}
-    elseif fieldname === :bc
-        return getfield(ctx, :bc)::Vector{UInt64}
-    elseif fieldname === :used
-        return getfield(ctx, :used)::Bool
-    else
-        error("type ", typeof(ctx), " has no field ", fieldname)
-    end
 end
 
 # Define constants via functions so as not to bloat context objects.  Yay dispatch!


### PR DESCRIPTION
Close #77

I've checked all `SHA2_CTX` and `SHA3_CTX` subtypes usage  by using JuliaHub.

Only a few packages use SHA.jl directly.
All packages use only the exported API.
So it seems safe to remove this code.

To be on the safe side, we could run pkg-eval the next time you update the SHA version in julia.

- https://juliahub.com/ui/Search?q=SHA2_256_CTX&type=symbols
- https://juliahub.com/ui/Search?q=SHA2_512_CTX&type=symbols
- https://juliahub.com/ui/Search?q=SHA256_CTX&type=symbols
