### PR TITLE
ci: update julia to new LTS v1.10

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -22,7 +22,6 @@ jobs:
       matrix:
         os:
           - ubuntu-latest
-          - macOS-latest
           - windows-latest
         julia-arch:
           - 'x64'
@@ -30,9 +29,11 @@ jobs:
         julia-version:
           - '1.10'  # LTS
           - 'nightly'
-        exclude:
+        include:
+          # NOTE: macOS-latest+x64 == rosetta on apple silicon
           - os: macOS-latest
-            julia-arch: x86
+            julia-version: ['1.10', 'nightly']
+            julia-arch: aarch64
     steps:
       - uses: actions/checkout@v4
       - uses: julia-actions/setup-julia@latest

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -32,7 +32,10 @@ jobs:
         include:
           # NOTE: macOS-latest+x64 == rosetta on apple silicon
           - os: macOS-latest
-            julia-version: ['1.10', 'nightly']
+            julia-version: '1.10'
+            julia-arch: aarch64
+          - os: macOS-latest
+            julia-version: '1.10'
             julia-arch: aarch64
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -28,7 +28,7 @@ jobs:
           - 'x64'
           - 'x86'
         julia-version:
-          - '1.6'
+          - '1.10'  # LTS
           - 'nightly'
         exclude:
           - os: macOS-latest


### PR DESCRIPTION
run on
- Julia v1.10
- macOS-latest - aarch64
