### PR TITLE
test: remove outdate tests

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -22,7 +22,7 @@ jobs:
       matrix:
         os:
           - ubuntu-latest
-          - macOS-latest
+          - macos-13 # Intel
           - windows-latest
         julia-arch:
           - 'x64'
@@ -31,7 +31,7 @@ jobs:
           - '1.6'
           - 'nightly'
         exclude:
-          - os: macOS-latest
+          - os: macos-13 # Intel
             julia-arch: x86
     steps:
       - uses: actions/checkout@v4

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -156,11 +156,6 @@ end
 end
 
 @testset "codecov" begin
-    @test_throws ErrorException("type SHA2_256_CTX has no field _not_exist") SHA.SHA2_256_CTX()._not_exist
-    @test_throws ErrorException("type SHA3_256_CTX has no field _not_exist") SHA.SHA3_256_CTX()._not_exist
-    # default fallback
-    @test_throws ErrorException("type SHA1_CTX has no field _not_exist") SHA.SHA1_CTX()._not_exist
-
     # Table 3: Input block sizes for HMAC
     #   https://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.202.pdf
     #        SHA3-224 -256 -384 -512


### PR DESCRIPTION
`Base.getproperty` was removed in #99.

With https://github.com/JuliaLang/julia/pull/54504, those tests will fail.

