### PR TITLE
Fix type mismatch for `shake` and setup x86 ci

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -38,6 +38,7 @@ jobs:
       - uses: julia-actions/setup-julia@latest
         with:
           version: ${{ matrix.julia-version }}
+          arch: ${{ matrix.julia-arch }}
       # Alter the UUID so that we test this package instead of loading
       # the version that is already built into a Julia's system image.
       - run: julia --color=yes .ci/test_and_change_uuid.jl

--- a/src/shake.jl
+++ b/src/shake.jl
@@ -99,10 +99,12 @@ function digest!(context::T,d::UInt,p::Ptr{UInt8}) where {T<:SHAKE}
         end 
         context.used = true
         p+=blocklen(T)
-        digest!(context,d-blocklen(T),p)
+        next_d_len = UInt(d - blocklen(T))
+        digest!(context, next_d_len, p)
         return 
     end
 end
+
 """
     shake128(data::AbstractBytes,d::UInt)
 


### PR DESCRIPTION
Fix #118