### PR TITLE
remove `@time` from tests

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -182,6 +182,6 @@ end
         @test SHA.shake256(b"",UInt(32)) == hex2bytes("46b9dd2b0ba88d13233b3feb743eeb243fcd52ea62b81b82b50c27646ed5762f")
         @test SHA.shake256(codeunits("0"^135),UInt(32)) == hex2bytes("ab11f61b5085a108a58670a66738ea7a8d8ce23b7c57d64de83eaafb10923cf8")
     end
-    @time SHA.shake256(b"abc",UInt(100000))
-    @time SHA.shake128(b"abc",UInt(100000))
+    SHA.shake256(b"abc",UInt(100000))
+    SHA.shake128(b"abc",UInt(100000))
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -182,6 +182,4 @@ end
         @test SHA.shake256(b"",UInt(32)) == hex2bytes("46b9dd2b0ba88d13233b3feb743eeb243fcd52ea62b81b82b50c27646ed5762f")
         @test SHA.shake256(codeunits("0"^135),UInt(32)) == hex2bytes("ab11f61b5085a108a58670a66738ea7a8d8ce23b7c57d64de83eaafb10923cf8")
     end
-    SHA.shake256(b"abc",UInt(100000))
-    SHA.shake128(b"abc",UInt(100000))
 end


### PR DESCRIPTION
These are noisy on Base CI. 

Should both lines just be removed instead? Or are they testing that they don't error?

They were added in https://github.com/JuliaCrypto/SHA.jl/pull/92

```
  | 2025-01-19 15:18:12 EST | From worker 7:	  0.012981 seconds (19 allocations: 98.805 KiB)
  | 2025-01-19 15:18:12 EST | From worker 7:	  0.010351 seconds (19 allocations: 98.867 KiB)
  | 2025-01-19 15:18:12 EST | SHA                                               (7) \|   118.92 \|   0.13 \|  0.1 \|     361.09 \|  1452.17

```